### PR TITLE
fix: hides table of content when selecting monster

### DIFF
--- a/src/features/monsters/components/BackToAllMonsters.tsx
+++ b/src/features/monsters/components/BackToAllMonsters.tsx
@@ -6,7 +6,7 @@ export const BackToAllMonsters = () => {
   const t = useAppSelector(selectTranslateFunction(['monster', 'common']))
 
   return (
-    <div className="2xl:hidden">
+    <div>
       <LinkWithIcon to="/monsters" icon="back">
         {t('monster:back_to_all_monsters')}
       </LinkWithIcon>

--- a/src/features/monsters/pages/monsters.page.tsx
+++ b/src/features/monsters/pages/monsters.page.tsx
@@ -177,9 +177,7 @@ export const MonstersPage = () => {
               </div>
 
               <div
-                className={`${
-                  monsterSection === undefined ? '' : 'hidden 2xl:block'
-                }`}
+                className={`${monsterSection === undefined ? '' : 'hidden'}`}
               >
                 <MonsterTableOfContents />
               </div>


### PR DESCRIPTION
closes #379 