### PR TITLE
chore: Added golem, clay as Community monster

### DIFF
--- a/src/features/monsters/community-monster.model.ts
+++ b/src/features/monsters/community-monster.model.ts
@@ -26,6 +26,12 @@ export type CommunityMonsterAttackType =
   | 'webshot'
   | 'piercing_shriek'
   | 'call_the_brood'
+  | 'claySmash'
+  | 'clayPunch'
+  | 'hastyReaction'
+  | 'earthRumble'
+  | 'groundQuake'
+  | 'golemRampage'
 
 export type Credit = {
   name: string

--- a/src/features/monsters/data/community-monster.data.ts
+++ b/src/features/monsters/data/community-monster.data.ts
@@ -147,4 +147,102 @@ export const communityMonsters: CommunityMonster[] = [
       },
     ],
   },
+  {
+    id: 'golem-clay',
+    name: 'common:community_monster.golem_clay.name',
+    description: 'common:community_monster.golem_clay.description',
+    credits: [{ name: 'Craig Atkins' }],
+    attributes: {
+      ...defaultAttributes,
+      strength: 11,
+      agility: 3,
+    },
+    armor: {
+      label: 'shell',
+      values: [false, false, false, false, false],
+    },
+    movement: {
+      distance: 1,
+      type: 'running',
+    },
+    skills: {
+      melee: 0,
+      move: 0,
+      scouting: 0,
+      stealth: 0,
+    },
+    attacks: [
+      {
+        type: 'claySmash',
+        range: 'armsLength',
+        damage: () => ({
+          blunt:  1,
+        }),
+        attack: () => 9,
+        singleUse: false,
+        valid: (_ctx) => true,
+        description: 'monster:attack.clay_smash.description',
+        chance: 1,
+      },
+      {
+        type: 'clayPunch',
+        range: 'armsLength',
+        damage: () => ({
+          blunt: 1,
+        }),
+        attack: () => 10,
+        singleUse: false,
+        valid: (_ctx) => true,
+        description: 'monster:attack.clay_punch.description',
+        chance: 1,
+      },
+      {
+        type: 'hastyReaction',
+        range: 'armsLength',
+        damage: () => ({
+        }),
+        attack: () => 0,
+        singleUse: false,
+        valid: (_ctx) => true,
+        description: 'monster:attack.hasty_reaction.description',
+        chance: 1,
+      },
+      {
+        type: 'earthRumble',
+        range: 'short',
+        damage: (_ctx) => ({
+          fear: true,
+        }),
+        attack: (_ctx) => 8,
+        singleUse: false,
+        valid: (_ctx) => true,
+        description: 'monster:attack.earth_rumble.description',
+        chance: 1,
+      },
+      {
+        type: 'groundQuake',
+        range: 'near',
+        damage: (_ctx) => ({
+          blunt: 1,
+        }),
+        attack: (_ctx) => 7,
+        singleUse: false,
+        valid: (_ctx) => true,
+        description: 'monster:attack.ground_quake.description',
+        chance: 1,
+      },
+      {
+        type: 'golemRampage',
+        range: 'armsLength',
+        singleUse: false,
+        attack: (_ctx) => 8,
+        damage: (_ctx) => ({
+          blunt: 2,
+        }),
+        valid: (_ctx) => true,
+        description: 'monster:attack.golem_rampage.description',
+        chance: 1,
+      },
+    ],
+  },
 ]

--- a/src/features/monsters/data/community-monster.data.ts
+++ b/src/features/monsters/data/community-monster.data.ts
@@ -176,7 +176,7 @@ export const communityMonsters: CommunityMonster[] = [
         type: 'claySmash',
         range: 'armsLength',
         damage: () => ({
-          blunt:  1,
+          blunt: 1,
         }),
         attack: () => 9,
         singleUse: false,
@@ -199,8 +199,7 @@ export const communityMonsters: CommunityMonster[] = [
       {
         type: 'hastyReaction',
         range: 'armsLength',
-        damage: () => ({
-        }),
+        damage: () => ({}),
         attack: () => 0,
         singleUse: false,
         valid: (_ctx) => true,

--- a/src/features/monsters/monster.model.ts
+++ b/src/features/monsters/monster.model.ts
@@ -350,7 +350,7 @@ export const monsterAttackTypeTranslationDict: Record<
   hastyReaction: 'monster:attack.hasty_reaction.type',
   earthRumble: 'monster:attack.earth_rumble.type',
   groundQuake: 'monster:attack.ground_quake.type',
-  golemRampage: 'monster:attack.golem_rampage.type'
+  golemRampage: 'monster:attack.golem_rampage.type',
 }
 export type MonsterDamageType =
   | 'slash'

--- a/src/features/monsters/monster.model.ts
+++ b/src/features/monsters/monster.model.ts
@@ -345,6 +345,12 @@ export const monsterAttackTypeTranslationDict: Record<
   pounce: 'monster:attack.pounce.type',
   stab: 'monster:attack.stab.type',
   webshot: 'monster:attack.webshot.type',
+  claySmash: 'monster:attack.clay_smash.type',
+  clayPunch: 'monster:attack.clay_punch.type',
+  hastyReaction: 'monster:attack.hasty_reaction.type',
+  earthRumble: 'monster:attack.earth_rumble.type',
+  groundQuake: 'monster:attack.ground_quake.type',
+  golemRampage: 'monster:attack.golem_rampage.type'
 }
 export type MonsterDamageType =
   | 'slash'

--- a/src/store/translations/translation.data.en.ts
+++ b/src/store/translations/translation.data.en.ts
@@ -235,6 +235,11 @@ export const translationsEn = {
         name: 'Giant Spiderling',
         description: '',
       },
+      golem_clay: {
+        name: 'Golem, Clay',
+        description: `To summon a creature of this power and ability takes a master spell caster. First the summoner must either cast a Summon Golem spell with Power Level of at least 4, or find an otherwise dormant Golem. A Summon Elemental spell, also with Power Level 4 then needs to be cast to imbue the Golem form with an elemental spirit. This powerful creature remains under the casters control for one turn (15 minutes), as long as the caster stays within SHORT range and keeps the Golem in sight. The caster can maintain control by again casting the same Power Level of Summon Elemental spell. If the spell caster becomes BROKEN, the Golem gains a semblance of free-will.
+        If the spell caster does not keep in command of the Golem, it wanders away, exploring its environment with child-like fascination. The body of the Golem will turn into an inanimate statue after a Quarter Day, it is unknown what happens to the elemental spirit once this occurs.`,
+      }
     },
     direction: {
       north: 'north',
@@ -1610,6 +1615,32 @@ export const translationsEn = {
       generic: {
         type: 'Attack',
         description: 'The beast attacks one adventurer.',
+      },
+      clay_smash: {
+        type: 'Clay Smash',
+        description:
+          `The Golem moves surprisingly quickly, punching wildly at two adventurers within ARM'S LENGTH, or one unlucky adventurer if they are the only target within reach. Make both attacks with nine Base Dice and Weapon Damage 1 (blunt force).`,
+      },
+      clay_punch: {
+        type: 'Clay Punch',
+        description: `The Golem strikes out with a large fist, striking the strongest adventurer at ARM'S LENGTH. Make an attack with ten Base Dice and Weapon Damage 1 (blunt force). If the attack hits, the victim must make a MOVE roll or be knocked prone.`
+      },
+      hasty_reaction: {
+        type: 'Hasty Reaction',
+        description:
+          'The Golem channels its internal power, releasing its built-up kinetic energy, making ungainly swift movements that confuse its enemies. The golem gains the ability to attempt to dodge all incoming attacks until after its next action, without falling prone. It also gains an additional slow action on its initiative in the next round.',
+      },
+      earth_rumble: {
+        type: 'Earth Rumble',
+        description: ` The Golem bangs its massive fists against its chest in an impressive display of dominance and aggression, sending out a cacophony of rumbling vibrations that terrify all living beings within SHORT range, all adventurers suffer a Fear attack using eight Base Dice.`
+      },
+      ground_quake: {
+        type: 'Ground Quake',
+        description: `The Golem smashes the ground with violent abandon, creating shockwaves in the earth, throwing up rocks and debris, and making the surrounding area unstable to walk on. Each adventurer within NEAR must make a MOVE roll or be thrown to the ground, they are also pelted with flying debris. Make each attack using seven Base Dice and Weapon Damage 1 (blunt force). The ground also becomes ROUGH terrain.`,
+      },
+      golem_rampage: {
+        type: 'Golem Rampage',
+        description: `The Golem goes berserk, moving to and attacking the nearest creature it can see. If no creature is near enough to move to and attack, the Golem attacks an object, with preference for an object smaller than itself. Make this attack using eight Base Dice and Weapon Damage 2 (blunt force). Once the Golem goes berserk, it continues to do so each round until it is destroyed or regains all its Strength. This attack can only become active after the Golem's Strength is reduced by half.`,
       },
     },
   },

--- a/src/store/translations/translation.data.en.ts
+++ b/src/store/translations/translation.data.en.ts
@@ -239,7 +239,7 @@ export const translationsEn = {
         name: 'Golem, Clay',
         description: `To summon a creature of this power and ability takes a master spell caster. First the summoner must either cast a Summon Golem spell with Power Level of at least 4, or find an otherwise dormant Golem. A Summon Elemental spell, also with Power Level 4 then needs to be cast to imbue the Golem form with an elemental spirit. This powerful creature remains under the casters control for one turn (15 minutes), as long as the caster stays within SHORT range and keeps the Golem in sight. The caster can maintain control by again casting the same Power Level of Summon Elemental spell. If the spell caster becomes BROKEN, the Golem gains a semblance of free-will.
         If the spell caster does not keep in command of the Golem, it wanders away, exploring its environment with child-like fascination. The body of the Golem will turn into an inanimate statue after a Quarter Day, it is unknown what happens to the elemental spirit once this occurs.`,
-      }
+      },
     },
     direction: {
       north: 'north',
@@ -1618,12 +1618,11 @@ export const translationsEn = {
       },
       clay_smash: {
         type: 'Clay Smash',
-        description:
-          `The Golem moves surprisingly quickly, punching wildly at two adventurers within ARM'S LENGTH, or one unlucky adventurer if they are the only target within reach. Make both attacks with nine Base Dice and Weapon Damage 1 (blunt force).`,
+        description: `The Golem moves surprisingly quickly, punching wildly at two adventurers within ARM'S LENGTH, or one unlucky adventurer if they are the only target within reach. Make both attacks with nine Base Dice and Weapon Damage 1 (blunt force).`,
       },
       clay_punch: {
         type: 'Clay Punch',
-        description: `The Golem strikes out with a large fist, striking the strongest adventurer at ARM'S LENGTH. Make an attack with ten Base Dice and Weapon Damage 1 (blunt force). If the attack hits, the victim must make a MOVE roll or be knocked prone.`
+        description: `The Golem strikes out with a large fist, striking the strongest adventurer at ARM'S LENGTH. Make an attack with ten Base Dice and Weapon Damage 1 (blunt force). If the attack hits, the victim must make a MOVE roll or be knocked prone.`,
       },
       hasty_reaction: {
         type: 'Hasty Reaction',
@@ -1632,7 +1631,7 @@ export const translationsEn = {
       },
       earth_rumble: {
         type: 'Earth Rumble',
-        description: ` The Golem bangs its massive fists against its chest in an impressive display of dominance and aggression, sending out a cacophony of rumbling vibrations that terrify all living beings within SHORT range, all adventurers suffer a Fear attack using eight Base Dice.`
+        description: ` The Golem bangs its massive fists against its chest in an impressive display of dominance and aggression, sending out a cacophony of rumbling vibrations that terrify all living beings within SHORT range, all adventurers suffer a Fear attack using eight Base Dice.`,
       },
       ground_quake: {
         type: 'Ground Quake',

--- a/src/store/translations/translation.data.sv.ts
+++ b/src/store/translations/translation.data.sv.ts
@@ -238,8 +238,7 @@ export const translationsSv: Translations = {
       },
       golem_clay: {
         name: 'Jord Golem',
-        description:
-          `För att tillkalla en varelse med denna kraft och förmåga krävs en mästare. Först måste kallaren antingen kasta en Summon Golem-trollformel med en kraftnivå på minst 4, eller hitta en annars vilande Golem. En Summon Elemental-trollformel, också med Power Level 4, måste sedan kastas för att genomsyra Golem-formen med en elementär anda. Denna kraftfulla varelse förblir under hjulens kontroll i ett varv (15 minuter), så länge som kastaren håller sig inom KORT räckvidd och håller Golem i sikte. Castern kan behålla kontrollen genom att återigen kasta samma Power Level of Summon Elemental-trollformel. Om trollformeln blir BRUTEN, får Golem ett sken av fri vilja.
+        description: `För att tillkalla en varelse med denna kraft och förmåga krävs en mästare. Först måste kallaren antingen kasta en Summon Golem-trollformel med en kraftnivå på minst 4, eller hitta en annars vilande Golem. En Summon Elemental-trollformel, också med Power Level 4, måste sedan kastas för att genomsyra Golem-formen med en elementär anda. Denna kraftfulla varelse förblir under hjulens kontroll i ett varv (15 minuter), så länge som kastaren håller sig inom KORT räckvidd och håller Golem i sikte. Castern kan behålla kontrollen genom att återigen kasta samma Power Level of Summon Elemental-trollformel. Om trollformeln blir BRUTEN, får Golem ett sken av fri vilja.
           Om trollformaren inte har kommandot över Golem, vandrar den iväg och utforskar sin miljö med barnliknande fascination. Golemens kropp kommer att förvandlas till en livlös staty efter en kvartsdag, det är okänt vad som händer med elementaranden när detta inträffar.`,
       },
     },
@@ -1614,12 +1613,11 @@ export const translationsSv: Translations = {
       },
       clay_smash: {
         type: 'Jordslag',
-        description:
-          `Golem rör sig förvånansvärt snabbt och slår vilt mot två äventyrare inom ARMLÄNGD, eller en olycklig äventyrare om de är det enda målet inom räckhåll. Gör båda attackerna med nio Bastärningar och vapenskada 1 (trubbig).`,
+        description: `Golem rör sig förvånansvärt snabbt och slår vilt mot två äventyrare inom ARMLÄNGD, eller en olycklig äventyrare om de är det enda målet inom räckhåll. Gör båda attackerna med nio Bastärningar och vapenskada 1 (trubbig).`,
       },
       clay_punch: {
         type: 'Jordsmäll',
-        description: `Golemen slår ut med en stor knytnäve och slår den starkaste äventyraren på ARMSLÄNGD. Gör en attack med tio Bastärningar och vapenskada 1 (trubbig kraft). Om attacken träffar måste offret göra ett Rörelse slag eller bli knockad.`
+        description: `Golemen slår ut med en stor knytnäve och slår den starkaste äventyraren på ARMSLÄNGD. Gör en attack med tio Bastärningar och vapenskada 1 (trubbig kraft). Om attacken träffar måste offret göra ett Rörelse slag eller bli knockad.`,
       },
       hasty_reaction: {
         type: 'Hastig Reaktion',
@@ -1628,7 +1626,7 @@ export const translationsSv: Translations = {
       },
       earth_rumble: {
         type: 'Jorddån',
-        description: ` Golem slår sina massiva nävar mot bröstet i en imponerande uppvisning av dominans och aggression, och sänder ut en kakofoni av mullrande vibrationer som skrämmer alla levande varelser inom KORT räckvidd, alla äventyrare utsätts för en rädslattacker med åtta bastärningar.`
+        description: ` Golem slår sina massiva nävar mot bröstet i en imponerande uppvisning av dominans och aggression, och sänder ut en kakofoni av mullrande vibrationer som skrämmer alla levande varelser inom KORT räckvidd, alla äventyrare utsätts för en rädslattacker med åtta bastärningar.`,
       },
       ground_quake: {
         type: 'Markbävning',

--- a/src/store/translations/translation.data.sv.ts
+++ b/src/store/translations/translation.data.sv.ts
@@ -236,6 +236,12 @@ export const translationsSv: Translations = {
         name: 'Jättespindelunge',
         description: '',
       },
+      golem_clay: {
+        name: 'Jord Golem',
+        description:
+          `För att tillkalla en varelse med denna kraft och förmåga krävs en mästare. Först måste kallaren antingen kasta en Summon Golem-trollformel med en kraftnivå på minst 4, eller hitta en annars vilande Golem. En Summon Elemental-trollformel, också med Power Level 4, måste sedan kastas för att genomsyra Golem-formen med en elementär anda. Denna kraftfulla varelse förblir under hjulens kontroll i ett varv (15 minuter), så länge som kastaren håller sig inom KORT räckvidd och håller Golem i sikte. Castern kan behålla kontrollen genom att återigen kasta samma Power Level of Summon Elemental-trollformel. Om trollformeln blir BRUTEN, får Golem ett sken av fri vilja.
+          Om trollformaren inte har kommandot över Golem, vandrar den iväg och utforskar sin miljö med barnliknande fascination. Golemens kropp kommer att förvandlas till en livlös staty efter en kvartsdag, det är okänt vad som händer med elementaranden när detta inträffar.`,
+      },
     },
     direction: {
       north: 'norr',
@@ -1605,6 +1611,32 @@ export const translationsSv: Translations = {
       generic: {
         type: 'Attack',
         description: 'Besten attackerar en äventyrare inom Armslängds avstånd.',
+      },
+      clay_smash: {
+        type: 'Jordslag',
+        description:
+          `Golem rör sig förvånansvärt snabbt och slår vilt mot två äventyrare inom ARMLÄNGD, eller en olycklig äventyrare om de är det enda målet inom räckhåll. Gör båda attackerna med nio Bastärningar och vapenskada 1 (trubbig).`,
+      },
+      clay_punch: {
+        type: 'Jordsmäll',
+        description: `Golemen slår ut med en stor knytnäve och slår den starkaste äventyraren på ARMSLÄNGD. Gör en attack med tio Bastärningar och vapenskada 1 (trubbig kraft). Om attacken träffar måste offret göra ett Rörelse slag eller bli knockad.`
+      },
+      hasty_reaction: {
+        type: 'Hastig Reaktion',
+        description:
+          'Golem kanaliserar sin inre kraft, frigör sin uppbyggda kinetiska energi och gör otympliga snabba rörelser som förvirrar dess fiender. Golemen får förmågan att försöka undvika alla inkommande attacker tills efter nästa åtgärd, utan att falla benägen. Den får också en ytterligare långsam handling på sitt initiativ i nästa omgång.',
+      },
+      earth_rumble: {
+        type: 'Jorddån',
+        description: ` Golem slår sina massiva nävar mot bröstet i en imponerande uppvisning av dominans och aggression, och sänder ut en kakofoni av mullrande vibrationer som skrämmer alla levande varelser inom KORT räckvidd, alla äventyrare utsätts för en rädslattacker med åtta bastärningar.`
+      },
+      ground_quake: {
+        type: 'Markbävning',
+        description: `Golem krossar marken med våldsam övergivning, skapar chockvågor i jorden, kastar upp stenar och skräp och gör det omgivande området instabilt att gå på. Varje äventyrare inom NÄRA måste göra ett Rörelse slag eller kastas till marken, de kastas också med flygande skräp. Gör varje attack med sju grundtärningar och vapenskada 1 (trubbig). Marken blir också GROV terräng.`,
+      },
+      golem_rampage: {
+        type: 'Golem berserk',
+        description: `Golem går berserk, flyttar till och attackerar den närmaste varelsen den kan se. Om ingen varelse är tillräckligt nära för att gå till och attackera, attackerar Golem ett föremål, med företräde för ett föremål som är mindre än det själv. Gör denna attack med åtta Bastärningar och vapenskada 2 (trubbig). När Golem går amok fortsätter den att göra det varje omgång tills den förstörs eller återfår all sin styrka. Denna attack kan bara bli aktiv efter att Golems styrka har halverats.`,
       },
     },
   },


### PR DESCRIPTION
Adds Golem, Clay to Community Monsters.
#361 

However, the stats below Armor is currently not possible to implement. Need to add optional fields in the future to make this possible. 
https://is-it-a-monster.blogspot.com/2020/05/golem-clay.html